### PR TITLE
019: Cache OAuth credentials, take 3

### DIFF
--- a/Source/AuthorizedJSONClient.swift
+++ b/Source/AuthorizedJSONClient.swift
@@ -25,10 +25,14 @@ open class AuthorizedJSONClient: JSONClient {
     ///
     /// - parameter oAuth: The OAuth authentication mode. This will be either
     ///             `OAuth1Swift` or `OAuth2Swift`.
+    /// - parameter authorizeUrl: For the purposes of this class, this is used
+    ///             as the `UserDefaults` key for storing the OAuth
+    ///             credential.
     /// - parameter baseUrl: The API URL that all paths will be resolved
     ///             against. If it's `nil` (the default), then each path that's
     ///             passed to the REST functions must be an absolute URL string.
     public init(oAuth: OAuthSwift,
+                authorizeUrl: String,
                 baseUrl: URL? = nil) {
         self.oAuth = oAuth
         super.init(baseUrl: baseUrl)

--- a/Source/AuthorizedJSONClient.swift
+++ b/Source/AuthorizedJSONClient.swift
@@ -35,7 +35,7 @@ open class AuthorizedJSONClient: JSONClient {
                 do {
                     return try JSONDecoder().decode(OAuthSwiftCredential.self, from: cachedData)
                 } catch {
-                    assertionFailure("Failed to retrieve the cached OAuthCredential: \(error.localizedDescription)")
+                    assertionFailure("Failed to decode the cached OAuth credential: \(error.localizedDescription)")
                     
                     return nil
                 }
@@ -45,12 +45,12 @@ open class AuthorizedJSONClient: JSONClient {
         }
 
         set {
-            if let credential = oAuthCredential {
+            if let credential = newValue {
                 do {
                     let cachedData: Data = try JSONEncoder().encode(credential)
                     defaults.set(cachedData, forKey: authorizeUrl)
                 } catch {
-                    assertionFailure("Failed to cache the OAuth credential: \(error.localizedDescription)")
+                    assertionFailure("Failed to encode the OAuth credential: \(error.localizedDescription)")
                 }
             }
         }

--- a/Source/AuthorizedJSONClient.swift
+++ b/Source/AuthorizedJSONClient.swift
@@ -7,8 +7,11 @@ import PromiseKit
 /// authorized REST calls for restricted resources.
 open class AuthorizedJSONClient: JSONClient {
 
-    // MARK: - Properties
+    // MARK: - Public Properties
 
+    /// The defaults object where the client's OAuth credential will be stored.
+    
+    open var defaults: UserDefaults = UserDefaults.standard
 
     /// The OAuth authentication mode that the client will use for
     /// authorization. This will be either `OAuth1Swift` or `OAuth2Swift`.
@@ -18,6 +21,13 @@ open class AuthorizedJSONClient: JSONClient {
     /// headers in calls to the server. Subclasses should assign a value to
     /// this once the user successfully authenticates with the server.
     var oAuthClient: OAuthSwiftClient?
+
+    // MARK: Internal Properties
+
+    /// The service's endpoint for initiating an authorization sequence. This
+    /// is used internally as the `UserDefaults` key for storing the OAuth
+    /// credential.
+    fileprivate var authorizeUrl: String
 
     // MARK: - Initialization
 
@@ -35,6 +45,7 @@ open class AuthorizedJSONClient: JSONClient {
                 authorizeUrl: String,
                 baseUrl: URL? = nil) {
         self.oAuth = oAuth
+        self.authorizeUrl = authorizeUrl
         super.init(baseUrl: baseUrl)
     }
 

--- a/Source/AuthorizedJSONClient.swift
+++ b/Source/AuthorizedJSONClient.swift
@@ -10,7 +10,7 @@ open class AuthorizedJSONClient: JSONClient {
     // MARK: - Public Properties
 
     /// The defaults object where the client's OAuth credential will be stored.
-    
+
     open var defaults: UserDefaults = UserDefaults.standard
 
     /// The OAuth authentication mode that the client will use for
@@ -28,6 +28,33 @@ open class AuthorizedJSONClient: JSONClient {
     /// is used internally as the `UserDefaults` key for storing the OAuth
     /// credential.
     fileprivate var authorizeUrl: String
+
+    internal var oAuthCredential: OAuthSwiftCredential? {
+        get {
+            if let cachedData = defaults.object(forKey: authorizeUrl) as? Data {
+                do {
+                    return try JSONDecoder().decode(OAuthSwiftCredential.self, from: cachedData)
+                } catch {
+                    assertionFailure("Failed to retrieve the cached OAuthCredential: \(error.localizedDescription)")
+                    
+                    return nil
+                }
+            } else {
+                return nil
+            }
+        }
+
+        set {
+            if let credential = oAuthCredential {
+                do {
+                    let cachedData: Data = try JSONEncoder().encode(credential)
+                    defaults.set(cachedData, forKey: authorizeUrl)
+                } catch {
+                    assertionFailure("Failed to cache the OAuth credential: \(error.localizedDescription)")
+                }
+            }
+        }
+    }
 
     // MARK: - Initialization
 

--- a/Source/AuthorizedJSONClient.swift
+++ b/Source/AuthorizedJSONClient.swift
@@ -9,14 +9,15 @@ open class AuthorizedJSONClient: JSONClient {
 
     // MARK: - Properties
 
-    /// The client that handles OAuth authorization and inserts the relevant
-    /// headers in calls to the server. Subclasses should assign a value to
-    /// this once the user successfully authenticates with the server.
-    var oAuthClient: OAuthSwiftClient?
 
     /// The OAuth authentication mode that the client will use for
     /// authorization. This will be either `OAuth1Swift` or `OAuth2Swift`.
     var oAuth: OAuthSwift
+
+    /// The client that handles OAuth authorization and inserts the relevant
+    /// headers in calls to the server. Subclasses should assign a value to
+    /// this once the user successfully authenticates with the server.
+    var oAuthClient: OAuthSwiftClient?
 
     // MARK: - Initialization
 

--- a/Source/OAuth1JSONClient.swift
+++ b/Source/OAuth1JSONClient.swift
@@ -8,6 +8,11 @@ import UIKit
 /// authentication and authorization.
 open class OAuth1JSONClient: AuthorizedJSONClient {
     
+    /// The storage location of the `OAuthSwiftCredential`. By default, this is
+    /// `UserDefaults.standard`, but it can be assigned to other defaults if
+    /// needed, such as for unit testing.
+    open var defaults: UserDefaults = UserDefaults.standard
+
     /// The OAuth engine. Note that there's already an `oAuth` property in the
     /// superclass, and its type is `OAuthSwift`, which is the superclass of
     /// `OAuth1Swift`. This one is here so that we don't have to cast the
@@ -41,7 +46,7 @@ open class OAuth1JSONClient: AuthorizedJSONClient {
                              requestTokenUrl: requestTokenUrl,
                              authorizeUrl: authorizeUrl,
                              accessTokenUrl: accessTokenUrl)
-        super.init(oAuth: oAuth1, baseUrl: baseUrl)
+        super.init(oAuth: oAuth1, authorizeUrl: authorizeUrl, baseUrl: baseUrl)
     }
 
     /// Launch the service's sign-in page in a modal Safari web view. After the

--- a/Source/OAuth1JSONClient.swift
+++ b/Source/OAuth1JSONClient.swift
@@ -7,11 +7,6 @@ import UIKit
 /// An `AuthorizedJSONClient` implementation that uses OAuth 1 for
 /// authentication and authorization.
 open class OAuth1JSONClient: AuthorizedJSONClient {
-    
-    /// The storage location of the `OAuthSwiftCredential`. By default, this is
-    /// `UserDefaults.standard`, but it can be assigned to other defaults if
-    /// needed, such as for unit testing.
-    open var defaults: UserDefaults = UserDefaults.standard
 
     /// The OAuth engine. Note that there's already an `oAuth` property in the
     /// superclass, and its type is `OAuthSwift`, which is the superclass of

--- a/Source/OAuth1JSONClient.swift
+++ b/Source/OAuth1JSONClient.swift
@@ -43,7 +43,7 @@ open class OAuth1JSONClient: AuthorizedJSONClient {
                              accessTokenUrl: accessTokenUrl)
         super.init(oAuth: oAuth1, baseUrl: baseUrl)
     }
-    
+
     /// Launch the service's sign-in page in a modal Safari web view. After the
     /// user has successfully authenticated, the web page will be redirected to
     /// the callback URL, which is unique to the client application.
@@ -65,7 +65,7 @@ open class OAuth1JSONClient: AuthorizedJSONClient {
                                         self?.oAuthClient = OAuthSwiftClient(credential: credential)
                                         seal.fulfill(credential)
                 }, failure: { (error) in
-                    _ = seal.reject(error)
+                    seal.reject(error)
             })
         }
     }

--- a/Source/OAuth2JSONClient.swift
+++ b/Source/OAuth2JSONClient.swift
@@ -63,7 +63,8 @@ open class OAuth2JSONClient: AuthorizedJSONClient {
                         callbackUrlString: String,
                         scope: String = "") -> Promise<OAuthSwiftCredential> {
         oAuth2.authorizeURLHandler = SafariURLHandler(viewController: presentingViewController, oauthSwift: oAuth)
-        
+
+
         return Promise<OAuthSwiftCredential> { (seal) in
             _ = self.oAuth2.authorize(withCallbackURL: callbackUrlString,
                                       scope: scope,
@@ -72,7 +73,7 @@ open class OAuth2JSONClient: AuthorizedJSONClient {
                                         self?.oAuthClient = OAuthSwiftClient(credential: credentials)
                                         seal.fulfill(credentials)
                 }, failure: { (error) in
-                    _ = seal.reject(error)
+                    seal.reject(error)
             })
         }
     }

--- a/Source/OAuth2JSONClient.swift
+++ b/Source/OAuth2JSONClient.swift
@@ -42,7 +42,7 @@ open class OAuth2JSONClient: AuthorizedJSONClient {
                              authorizeUrl: authorizeUrl,
                              accessTokenUrl: accessTokenUrl,
                              responseType: "token")  // will it always be "token"?
-        super.init(oAuth: oAuth2, baseUrl: baseUrl)
+        super.init(oAuth: oAuth2, authorizeUrl: authorizeUrl, baseUrl: baseUrl)
     }
     
     /// Launch the service's sign-in page in a modal Safari web view. After the

--- a/Tests/AuthorizedJSONClientTests.swift
+++ b/Tests/AuthorizedJSONClientTests.swift
@@ -112,6 +112,17 @@ class AuthorizedJSONClientTests: JSONClientTests {
         }
     }
 
+    func testSetCredentialInStandardDefaultsOk() {
+        let key = "aslkdfj3q4fal;ksdfjal;skdfj"
+        let secret = "asdlkfj3l4kjrtl;kad meerlktjl;3k4j"
+        let credential = OAuthSwiftCredential(consumerKey: key, consumerSecret: secret)
+
+        let client = validJSONClient() as! AuthorizedJSONClient
+        client.oAuthCredential = credential
+        let decodedCredential = client.oAuthCredential
+        XCTAssertEqual(credential, decodedCredential)
+    }
+
     func assert<T: Codable>(promise: Promise<T>,
                             wasUnauthorizedWithMessage errorMessage: String) {
         let exp = expectation(description: errorMessage)

--- a/Tests/AuthorizedJSONClientTests.swift
+++ b/Tests/AuthorizedJSONClientTests.swift
@@ -121,6 +121,8 @@ class AuthorizedJSONClientTests: JSONClientTests {
         client.oAuthCredential = credential
         let decodedCredential = client.oAuthCredential
         XCTAssertEqual(credential, decodedCredential)
+
+        client.oAuthCredential = nil
     }
 
     func assert<T: Codable>(promise: Promise<T>,

--- a/Tests/AuthorizedJSONClientTests.swift
+++ b/Tests/AuthorizedJSONClientTests.swift
@@ -118,11 +118,14 @@ class AuthorizedJSONClientTests: JSONClientTests {
         let credential = OAuthSwiftCredential(consumerKey: key, consumerSecret: secret)
 
         let client = validJSONClient() as! AuthorizedJSONClient
+        let originalDefaults = client.defaults  // reset the client.defaults to this later
+        client.defaults = UserDefaults(suiteName: self.name)!  // custom defaults for testing
         client.oAuthCredential = credential
         let decodedCredential = client.oAuthCredential
         XCTAssertEqual(credential, decodedCredential)
 
         client.oAuthCredential = nil
+        client.defaults = originalDefaults
     }
 
     func assert<T: Codable>(promise: Promise<T>,

--- a/Tests/AuthorizedJSONClientTests.swift
+++ b/Tests/AuthorizedJSONClientTests.swift
@@ -10,7 +10,7 @@ class AuthorizedJSONClientTests: JSONClientTests {
     override func validJSONClient(baseUrl: URL? = nil) -> JSONClient {
         let oAuth = OAuth1Swift(consumerKey: "foo", consumerSecret: "bar")
         
-        return AuthorizedJSONClient(oAuth: oAuth, baseUrl: baseUrl)
+        return AuthorizedJSONClient(oAuth: oAuth, authorizeUrl: "http://www.cnn.com", baseUrl: baseUrl)
     }
 
     func testAuthorizedGetWithPathBeforeAuthorizationFails() {


### PR DESCRIPTION
Issue #19.

It's difficult to unit-test this because it requires a live server to fall back on if the cached credential is expired, and that's not easy in a headless unit test.